### PR TITLE
feat: run analysis also on ready_for_review, synchronize events

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -5,4 +5,4 @@ branding:
   color: 'green'
 runs:
   using: 'docker'
-  image: 'Dockerfile.github_action_dockerhub'
+  image: 'Dockerfile.github_action'

--- a/pr_agent/servers/github_action_runner.py
+++ b/pr_agent/servers/github_action_runner.py
@@ -47,17 +47,21 @@ async def run_action():
         print(f"Failed to parse JSON: {e}")
         return
 
+    print('handling ' + GITHUB_EVENT_NAME + ' event')
     # Handle pull request event
     if GITHUB_EVENT_NAME == "pull_request":
         action = event_payload.get("action")
+        print('handling ' + action + ' action')
         if action in ["opened", "reopened", "synchronize", "ready_for_review"]:
             pr_url = event_payload.get("pull_request", {}).get("url")
             if pr_url:
+                print('doing review of pr url:' + pr_url)
                 await PRReviewer(pr_url).run()
 
     # Handle issue comment event
     elif GITHUB_EVENT_NAME == "issue_comment":
         action = event_payload.get("action")
+        print('handling ' + action + ' action')
         if action in ["created", "edited"]:
             comment_body = event_payload.get("comment", {}).get("body")
             if comment_body:

--- a/pr_agent/servers/github_action_runner.py
+++ b/pr_agent/servers/github_action_runner.py
@@ -50,7 +50,7 @@ async def run_action():
     # Handle pull request event
     if GITHUB_EVENT_NAME == "pull_request":
         action = event_payload.get("action")
-        if action in ["opened", "reopened"]:
+        if action in ["opened", "reopened", "synchronize", "ready_for_review"]:
             pr_url = event_payload.get("pull_request", {}).get("url")
             if pr_url:
                 await PRReviewer(pr_url).run()


### PR DESCRIPTION
Run analysis on synchronize/ready_for_review events as well.
If a github actions operator does not want this, he can choose for more selective triggers in the gh actions definitions